### PR TITLE
避免API验证时有空格导致错误

### DIFF
--- a/backend/.env.dev.example
+++ b/backend/.env.dev.example
@@ -29,6 +29,7 @@ MAX_RETRIES=5
 # E2B_API_KEY=
 SERVER_HOST=http://localhost:8000
 # 使用 email 注册账号从 https://openalex.org/ 文献
+# OPENALEX_EMAIL=example@example.com
 OPENALEX_EMAIL=
 
 LOG_LEVEL=DEBUG

--- a/backend/app/core/workflow.py
+++ b/backend/app/core/workflow.py
@@ -81,7 +81,7 @@ class MathModelWorkFlow(WorkFlow):
             notebook_serializer=notebook_serializer,
             timeout=3000,
         )
-
+        
         scholar = OpenAlexScholar(task_id=self.task_id, email=settings.OPENALEX_EMAIL)
 
         await redis_manager.publish_message(

--- a/frontend/src/pages/chat/components/ApiDialog.vue
+++ b/frontend/src/pages/chat/components/ApiDialog.vue
@@ -267,7 +267,7 @@ const links = {
             <div class="space-y-1">
               <Label :for="`${config.key}-api-key`" class="text-xs text-muted-foreground">API Key</Label>
               <div class="flex items-center gap-2">
-                <Input :id="`${config.key}-api-key`" v-model="(form as any)[config.key].apiKey" type="password"
+                <Input :id="`${config.key}-api-key`" v-model.trim="(form as any)[config.key].apiKey" type="password"
                   placeholder="请输入 API Key" class="h-7 text-xs flex-1" />
                 <div v-if="validationResults[config.key as keyof typeof validationResults].message"
                   class="flex items-center">
@@ -280,12 +280,12 @@ const links = {
             <div class="grid grid-cols-2 gap-2">
               <div class="space-y-1">
                 <Label :for="`${config.key}-base-url`" class="text-xs text-muted-foreground">Base URL</Label>
-                <Input :id="`${config.key}-base-url`" v-model="(form as any)[config.key].baseUrl"
+                <Input :id="`${config.key}-base-url`" v-model.trim="(form as any)[config.key].baseUrl"
                   placeholder="https://api.deepseek.com" class="h-7 text-xs" />
               </div>
               <div class="space-y-1">
                 <Label :for="`${config.key}-model-id`" class="text-xs text-muted-foreground">Model ID</Label>
-                <Input :id="`${config.key}-model-id`" v-model="(form as any)[config.key].modelId"
+                <Input :id="`${config.key}-model-id`" v-model.trim="(form as any)[config.key].modelId"
                   placeholder="provider/model_id" class="h-7 text-xs" />
               </div>
             </div>


### PR DESCRIPTION
API设置对话框内BaseURL和provider/ModelID输入时如果误复制空格会导致DeepseekException
在ApiDialog.vue文件当中使用v-model.trim过滤空格防止出错