### PR TITLE
加入了qwen百炼平台的选项和一个解耦后的测试api是否可用的脚本

### DIFF
--- a/backend/app/routers/modeling_router.py
+++ b/backend/app/routers/modeling_router.py
@@ -100,9 +100,7 @@ async def validate_api_key(request: ValidateApiKeyRequest):
             messages=[{"role": "user", "content": "Hi"}],
             max_tokens=1,
             api_key=request.api_key,
-            base_url=request.base_url
-            if request.base_url != "https://api.openai.com/v1"
-            else None,
+            base_url=request.base_url if request.base_url else None
         )
 
         return ValidateApiKeyResponse(valid=True, message="✓ 模型 API 验证成功")

--- a/backend/test_api.py
+++ b/backend/test_api.py
@@ -1,0 +1,70 @@
+import asyncio  
+import litellm  
+  
+async def validate_model_api(api_key: str, base_url: str, model_id: str):  
+    """  
+    验证模型 API 是否可用的最小脚本  
+      
+    Args:  
+        api_key: API 密钥  
+        base_url: API 基础 URL (例如: https://api.openai.com/v1)  
+        model_id: 模型标识符 (例如: gpt-4, deepseek/deepseek-chat)  
+      
+    Returns:  
+        dict: {"valid": bool, "message": str}  
+    """  
+    try:  
+        # 构建请求参数  
+        kwargs = {  
+            "model": model_id,  
+            "messages": [{"role": "user", "content": "Hi"}],  
+            "max_tokens": 1,  
+            "api_key": api_key,  
+        }  
+          
+        # 只有当 base_url 存在时才添加  
+        if base_url:  
+            kwargs["base_url"] = base_url  
+          
+        # 发送测试请求  
+        await litellm.acompletion(**kwargs)  
+          
+        return {  
+            "valid": True,  
+            "message": "✓ 模型 API 验证成功"  
+        }  
+          
+    except Exception as e:  
+        error_msg = str(e)  
+          
+        # 解析常见错误类型  
+        if "401" in error_msg or "Unauthorized" in error_msg:  
+            message = "✗ API Key 无效或已过期"  
+        elif "404" in error_msg or "Not Found" in error_msg:  
+            message = "✗ 模型 ID 不存在或 Base URL 错误"  
+        elif "429" in error_msg or "rate limit" in error_msg.lower():  
+            message = "✗ 请求过于频繁,请稍后再试"  
+        elif "403" in error_msg or "Forbidden" in error_msg:  
+            message = "✗ API 权限不足或账户余额不足"  
+        else:  
+            message = f"✗ 验证失败: {error_msg[:100]}"  
+          
+        return {  
+            "valid": False,  
+            "message": message  
+        }  
+  
+  
+# 使用示例  
+async def main():  
+
+    result = await validate_model_api(  
+        api_key="",  
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        model_id="openai/qwen3-max"
+    )  
+    print(f"Qwen: {result}")  
+      
+  
+if __name__ == "__main__":  
+    asyncio.run(main())

--- a/frontend/src/pages/chat/components/ApiDialog.vue
+++ b/frontend/src/pages/chat/components/ApiDialog.vue
@@ -234,6 +234,12 @@ const providers = {
     "baseUrl": "https://api.deepseek.com",
     "modelId": "deepseek/deepseek-chat"
   },
+  千问百炼: {
+    url: "https://dashscope.console.aliyun.com/apiKey",
+    key: "千问百炼",
+    baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    modelId: "openai/qwen3-max",
+  },
   "硅基流动": {
     "url": "https://cloud.siliconflow.cn/i/UIb4Enf4",
     "key": "硅基流动",


### PR DESCRIPTION
# 我在尝试使用qwen模型的过程中发现`litellm`官方提供的样例无法使用，下面是我的解决方案
litellm文档中给出的`dashscope/qwen-turbo`的形式在实际使用中并无法正确运行
下面是报错
```bash
litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. 
You passed model=dashscope/qwen3-max
Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` 
Learn more: https://docs.litellm.ai/docs/providers
```
可以注意到`litellm`文档标注的网址`https://dashscope.console.aliyun.com/`当前已经停接近停止服务
我提取出了项目中对于api验证的部分，构建了最小的api和模型提供格式的验证脚本
查阅官网可知，当前中国大陆地区替换为了`https://dashscope.aliyuncs.com/compatible-mode/v1`
但是使用这个网址还是无发链接，出现相同报错。
经过测试，发现`openai/model_id`的格式是可以通过验证的
为了方便使用，我在前端加入了千问百炼平台的模板
<img 
  src="https://github.com/user-attachments/assets/c75fe6f0-90d7-4e95-83f7-49b3c14d6792" 
  alt="image" 
  style="width: 50%; height: 50%;"
/>

