### PR TITLE
fix: 透传 reasoning_content，修复 MiMo thinking 模式下的 400 错误

### DIFF
--- a/backend/app/core/agents/agent.py
+++ b/backend/app/core/agents/agent.py
@@ -64,7 +64,19 @@ class Agent:
                 sub_title=sub_title,
             )
             response_content = response.content
-            self.chat_history.append({"role": "assistant", "content": response_content})
+            assistant_msg: dict = {"role": "assistant", "content": response_content}
+            if response.reasoning_content:
+                assistant_msg["reasoning_content"] = response.reasoning_content
+            if response.tool_calls:
+                assistant_msg["tool_calls"] = [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {"name": tc.name, "arguments": tc.arguments},
+                    }
+                    for tc in response.tool_calls
+                ]
+            self.chat_history.append(assistant_msg)
 
             # 使用 API 返回的实际 prompt_tokens 更新计数
             if response.usage.prompt_tokens > 0:

--- a/backend/app/core/agents/coder_agent.py
+++ b/backend/app/core/agents/coder_agent.py
@@ -140,6 +140,8 @@ class CoderAgent(Agent):
 
                         # 更新对话历史 - 添加助手的响应
                         assistant_msg: dict = {"role": "assistant", "content": response.content}
+                        if response.reasoning_content:
+                            assistant_msg["reasoning_content"] = response.reasoning_content
                         if response.tool_calls:
                             assistant_msg["tool_calls"] = [
                                 {

--- a/backend/app/core/agents/modeler_agent.py
+++ b/backend/app/core/agents/modeler_agent.py
@@ -101,9 +101,10 @@ class ModelerAgent(Agent):
             logger.warning(
                 f"JSON 解析失败 (第{attempt}次)，请求模型重新生成"
             )
-            await self.append_chat_history(
-                {"role": "assistant", "content": json_str}
-            )
+            retry_msg: dict = {"role": "assistant", "content": json_str}
+            if response.reasoning_content:
+                retry_msg["reasoning_content"] = response.reasoning_content
+            await self.append_chat_history(retry_msg)
             await self.append_chat_history(
                 {
                     "role": "user",

--- a/backend/app/core/agents/writer_agent.py
+++ b/backend/app/core/agents/writer_agent.py
@@ -115,6 +115,8 @@ class WriterAgent(Agent):
 
                 # 更新对话历史 - 添加助手的响应
                 assistant_msg: dict = {"role": "assistant", "content": response.content}
+                if response.reasoning_content:
+                    assistant_msg["reasoning_content"] = response.reasoning_content
                 if response.tool_calls:
                     assistant_msg["tool_calls"] = [
                         {
@@ -157,7 +159,7 @@ class WriterAgent(Agent):
                 response_content = next_response.content or ""
         else:
             response_content = response.content or ""
-        self.chat_history.append({"role": "assistant", "content": response_content})
+        self.chat_history.append({"role": "assistant", "content": response_content, "reasoning_content": response.reasoning_content} if response.reasoning_content else {"role": "assistant", "content": response_content})
         logger.info(f"{self.__class__.__name__}:完成:执行对话")
         return WriterResponse(response_content=response_content, footnotes=footnotes)
 
@@ -172,9 +174,10 @@ class WriterAgent(Agent):
                 history=self.chat_history, agent_name=self.__class__.__name__
             )
             response_content = response.content or ""
-            await self.append_chat_history(
-                {"role": "assistant", "content": response_content}
-            )
+            summary_msg: dict = {"role": "assistant", "content": response_content}
+            if response.reasoning_content:
+                summary_msg["reasoning_content"] = response.reasoning_content
+            await self.append_chat_history(summary_msg)
             return response_content
         except Exception as e:
             logger.error(f"总结生成失败: {str(e)}")

--- a/backend/app/core/llm/providers/openai_chat.py
+++ b/backend/app/core/llm/providers/openai_chat.py
@@ -49,4 +49,10 @@ class OpenAIChatProvider(BaseProvider):
             completion_tokens=response.usage.completion_tokens if response.usage else 0,
         )
 
-        return StandardResponse(content=message.content, tool_calls=tool_calls, usage=usage)
+        reasoning = getattr(message, "reasoning_content", None)
+        return StandardResponse(
+            content=message.content,
+            reasoning_content=reasoning,
+            tool_calls=tool_calls,
+            usage=usage,
+        )

--- a/backend/app/core/llm/types.py
+++ b/backend/app/core/llm/types.py
@@ -28,5 +28,6 @@ class StandardResponse:
     """
 
     content: str | None = None
+    reasoning_content: str | None = None
     tool_calls: list[ToolCall] = field(default_factory=list)
     usage: Usage = field(default_factory=Usage)


### PR DESCRIPTION
## 问题描述

使用开启 thinking 模式的 API（DeepSeek、小米 MiMo 2.5 Pro 等）时，第一次对话正常返回结果，但第二次调用立即报错：

```
Error code: 400 - Param Incorrect
param: The reasoning_content in the thinking mode must be passed back to the API.
```

该错误非瞬态故障，重试机制会陷入无限循环（已观察到 500+ 次重试），任务永远无法完成。

## 根因

当 LLM 开启 thinking 模式时，API 返回的 assistant 消息中除 `content` 外还包含 `reasoning_content` 字段。该 API 要求**下一轮请求必须将上一轮的 `reasoning_content` 原样带回**，否则拒绝请求。

当前代码在以下位置丢弃了 `reasoning_content`：

- `StandardResponse` 数据类未定义该字段
- `OpenAIChatProvider.call()` 未从响应中提取该字段
- 各 Agent 构建 assistant 消息时未包含该字段
- agent.py 基类的 `run()` 还遗漏了 `tool_calls` 的写入

## 修复内容

| 文件 | 修改 |
|------|------|
| `types.py` | `StandardResponse` 新增 `reasoning_content: str \| None` |
| `openai_chat.py` | `call()` 从 `message.reasoning_content` 提取并传递 |
| `agent.py` | `run()` 写入历史时携带 `reasoning_content` 和 `tool_calls` |
| `coder_agent.py` | 同上 |
| `writer_agent.py` | 同上（2 处） |
| `modeler_agent.py` | 同上 |

共修改 6 个文件，+34/-9 行。向后兼容——未启用 thinking 模式的 API 不会返回该字段，值为 `None` 时不会写入消息。

## 验证

- 使用小米 MiMo 2.5 Pro API 测试，修复前第二次对话 100% 复现 400 错误，修复后正常完成多轮对话
- 无 thinking 模式的标准 OpenAI API 行为不受影响