### PR TITLE
feat(task): 添加任务停止运行功能

### DIFF
--- a/.trae/documents/stop-running-button-plan.md
+++ b/.trae/documents/stop-running-button-plan.md
@@ -1,0 +1,262 @@
+# 停止运行按钮实现方案
+
+## 需求概述
+
+在任务详情页（`task/index.vue`）右上角区域（"下载结果"按钮旁）新增一个「停止运行」按钮，点击后可中止正在执行的任务。
+
+## 现状分析
+
+### 当前任务执行链路
+
+```
+POST /modeling → background_tasks.add_task()
+  → run_modeling_task_async()
+    → asyncio.create_task(MathModelWorkFlow().execute(problem))
+    → asyncio.wait_for(task, timeout=3600*5)  # 5小时硬超时
+```
+
+### 关键发现
+
+* **无取消机制**：没有 cancel API、没有 cancel\_event、没有任务注册表
+
+* **任务不可追踪**：`asyncio.create_task()` 创建后无法通过 task\_id 获取引用
+
+* **前端无运行状态**：没有 `isRunning`/`taskStatus` 字段，只能间接推断
+
+* **WebSocket 单向通信**：`send()` 方法存在但从未使用
+
+***
+
+## 实现步骤
+
+### Step 1：后端 — 建立任务注册与取消机制
+
+**文件**: [modeling\_router.py](backend/app/routers/modeling_router.py)
+
+1.1 新增模块级任务注册表：
+
+```python
+# 文件顶部新增
+import asyncio
+from typing import Dict, Tuple
+
+# 任务注册表: task_id -> (asyncio.Task, asyncio.Event)
+_active_tasks: Dict[str, Tuple[asyncio.Task, asyncio.Event]] = {}
+```
+
+1.2 修改 `run_modeling_task_async()` 函数：
+
+* 创建 `asyncio.Event()` 作为取消信号
+
+* 用 `asyncio.create_task()` 创建任务并存入 `_active_tasks`
+
+* 将 `cancel_event` 传入 `MathModelWorkFlow.execute()`
+
+* 任务完成/异常时从注册表中清理
+
+1.3 新增取消接口 `POST /modeling/{task_id}/cancel`：
+
+* 查找 `_active_tasks[task_id]`
+
+* 调用 `cancel_event.set()` 发送取消信号
+
+* 可选：调用 `task.cancel()` 作为兜底
+
+* 通过 Redis 发布取消通知给前端
+
+***
+
+### Step 2：后端 — 工作流层支持取消
+
+**文件**: [workflow.py](backend/app/core/workflow.py)
+
+2.1 `MathModelWorkFlow.__init__()` 接收 `cancel_event: asyncio.Event` 参数
+
+2.2 在 `execute()` 的关键检查点插入取消检测（每个 agent 调用前后）：
+
+```python
+# 在每个 agent.run() 调用前检查
+if self.cancel_event.is_set():
+    await redis_manager.publish_message(
+        self.task_id,
+        SystemMessage(content="任务已停止", type="warning"),
+    )
+    return
+```
+
+关键检查点位置：
+
+* CoordinatorAgent 调用前/后
+
+* ModelerAgent 调用前/后
+
+* 每个 solution\_flow 循环迭代开始时（CoderAgent + WriterAgent）
+
+* 每个 write\_flow 循环迭代开始时
+
+***
+
+### Step 3：后端 — Agent 层传播取消事件
+
+**文件**: [agent.py](backend/app/core/agents/agent.py) 及各子类 Agent
+
+3.1 `Agent.__init__()` 新增可选参数 `cancel_event: asyncio.Event | None = None`
+
+3.2 `Agent.run()` 在 `self.model.chat()` 调用外层包裹取消检测：
+
+```python
+# 使用 asyncio.wait 配合 cancel_event 实现可中断等待
+chat_task = asyncio.create_task(self.model.chat(...))
+done, pending = await asyncio.wait(
+    {chat_task, asyncio.create_task(self.cancel_event.wait())},
+    return_when=asyncio.FIRST_COMPLETED,
+)
+if self.cancel_event.is_set():
+    chat_task.cancel()
+    raise asyncio.CancelledError("任务被用户停止")
+```
+
+> 注：各子类 Agent（CoordinatorAgent、ModelerAgent、CoderAgent、WriterAgent）需将 `cancel_event` 透传给基类。
+
+***
+
+### Step 4：前端 — 新增取消 API
+
+**文件**: [commonApi.ts](frontend/src/apis/commonApi.ts)
+
+4.1 新增函数：
+
+```typescript
+/** 取消正在运行的任务 */
+export function cancelTask(task_id: string) {
+	return request.post<{ success: boolean; message: string }>(
+		`/modeling/${task_id}/cancel`,
+	);
+}
+```
+
+***
+
+### Step 5：前端 — Task Store 增加运行状态管理
+
+**文件**: [task.ts](frontend/src/stores/task.ts)
+
+5.1 新增状态：
+
+```typescript
+/** 任务是否正在运行 */
+const isRunning = ref(false);
+```
+
+5.2 新增 actions：
+
+```typescript
+/** 取消任务 */
+async function cancelTask(taskId: string) {
+	try {
+		const res = await cancelTaskAPI(taskId);
+		if (res.data.success) {
+			isRunning.value = false;
+		}
+	} catch (error) {
+		console.error("取消任务失败:", error);
+	}
+}
+```
+
+5.3 修改 `connectWebSocket()` / 消息处理逻辑：
+
+* 收到 `type="success"` 的 system message（"任务处理完成"）→ `isRunning = false`
+
+* 收到 `type="warning"` 的 system message（"任务已停止"）→ `isRunning = false`
+
+* 连接 WebSocket 时 → `isRunning = true`（假设进入页面时任务可能还在跑）
+
+5.4 在 return 中导出 `isRunning` 和 `cancelTask`
+
+***
+
+### Step 6：前端 — UI 添加停止按钮
+
+**文件**: [index.vue](frontend/src/pages/task/index.vue)（第 130-137 行区域）
+
+6.1 在 `<div class="flex justify-end gap-2 items-center">` 中，"下载消息"按钮前面插入：
+
+```vue
+<Button
+  v-if="taskStore.isRunning"
+  variant="destructive"
+  @click="handleStop"
+  :disabled="isStopping"
+>
+  <span v-if="isStopping">停止中...</span>
+  <span v-else>停止运行</span>
+</Button>
+```
+
+6.2 新增 `handleStop` 方法和 `isStopping` 状态：
+
+```typescript
+const isStopping = ref(false);
+
+async function handleStop() {
+	isStopping.value = true;
+	await taskStore.cancelTask(props.task_id);
+	isStopping.value = false;
+}
+```
+
+6.3 样式细节：
+
+* 使用 `variant="destructive"`（红色警告样式）区分于普通操作按钮
+
+* 停止中状态禁用按钮并显示 "停止中..." 防止重复点击
+
+***
+
+## 涉及文件清单
+
+| 文件                                             | 改动类型 | 说明                                 |
+| ---------------------------------------------- | ---- | ---------------------------------- |
+| `backend/app/routers/modeling_router.py`       | 修改   | 新增任务注册表 + 取消接口                     |
+| `backend/app/core/workflow.py`                 | 修改   | execute() 传入 cancel\_event 并在关键点检测 |
+| `backend/app/core/agents/agent.py`             | 修改   | 基类支持 cancel\_event，run() 可被中断      |
+| `backend/app/core/agents/coordinator_agent.py` | 修改   | 透传 cancel\_event                   |
+| `backend/app/core/agents/modeler_agent.py`     | 修改   | 透传 cancel\_event                   |
+| `backend/app/core/agents/coder_agent.py`       | 修改   | 透传 cancel\_event                   |
+| `backend/app/core/agents/writer_agent.py`      | 修改   | 透传 cancel\_event                   |
+| `frontend/src/apis/commonApi.ts`               | 修改   | 新增 cancelTask API                  |
+| `frontend/src/stores/task.ts`                  | 修改   | 新增 isRunning 状态和 cancelTask action |
+| `frontend/src/pages/task/index.vue`            | 修改   | 右上角添加停止按钮                          |
+
+## 取消机制流程图
+
+```
+用户点击「停止运行」
+  ↓
+前端 POST /modeling/{task_id}/cancel
+  ↓
+后端查找 _active_tasks[task_id]
+  ↓
+cancel_event.set()  ←── 设置取消信号
+  ↓
+同时 redis_manager.publish_message("任务已停止", type="warning")
+  ↓
+┌─────────────────────────────────┐
+│ 工作流 execute() 检测到信号     │
+│   ├─ 当前 agent 正在 LLM 调用   │ → asyncio.CancelledError → 向上冒泡
+│   └─ 当前 agent 之间（空闲期）   │ → 直接 return               │
+└─────────────────────────────────┘
+  ↓
+从 _active_tasks 中清理该任务
+  ↓
+前端收到 warning 类型 system message → isRunning = false → 按钮隐藏
+```
+
+## 边界情况处理
+
+1. **任务已完成再点取消**：后端返回任务不在注册表中，前端忽略即可
+2. **取消时 LLM 正在调用**：通过 `asyncio.wait` + `task.cancel()` 双重机制确保中断
+3. **页面刷新后丢失状态**：进入任务页时默认 `isRunning=true`，收到完成/停止消息后更新
+4. **代码沙盒 cleanup**：取消后仍需执行 `code_interpreter.cleanup()` 清理资源（在 finally 中）
+

--- a/backend/app/core/agents/agent.py
+++ b/backend/app/core/agents/agent.py
@@ -1,5 +1,6 @@
 """Agent 基类模块，提供对话管理和记忆压缩功能。"""
 
+import asyncio
 from typing import Any
 from app.core.llm.llm import LLM, simple_chat
 from app.utils.log_util import logger
@@ -21,6 +22,7 @@ class Agent:
         model: LLM,
         context_window: int = 128000,  # 模型上下文窗口大小（token）
         token_threshold_ratio: float = _DEFAULT_TOKEN_THRESHOLD_RATIO,
+        cancel_event: asyncio.Event | None = None,
     ) -> None:
         self.task_id = task_id
         self.model = model
@@ -28,6 +30,7 @@ class Agent:
         self.context_window = context_window
         self.token_threshold_ratio = token_threshold_ratio
         self.current_token_count = 0  # 当前历史的估算 token 数
+        self.cancel_event = cancel_event  # 取消信号
 
     def _estimate_tokens(self, text: str) -> int:
         """估算文本的 token 数量。"""
@@ -38,6 +41,31 @@ class Agent:
         content = msg.get("content") or ""
         # 4 token 额外开销（role、分隔符等）
         return self._estimate_tokens(content) + 4
+
+    async def _chat(self, **kwargs) -> Any:
+        """调用 LLM 模型，支持取消中断。
+
+        将所有关键字参数透传给 self.model.chat()。
+        若设置了 cancel_event，则通过 asyncio.wait 实现可中断等待。
+
+        Returns:
+            模型响应对象。
+        """
+        if not self.cancel_event:
+            return await self.model.chat(**kwargs)
+
+        chat_task = asyncio.create_task(self.model.chat(**kwargs))
+        cancel_wait_task = asyncio.create_task(self.cancel_event.wait())
+        done, pending = await asyncio.wait(
+            {chat_task, cancel_wait_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if cancel_wait_task in done:
+            chat_task.cancel()
+            for p in pending:
+                p.cancel()
+            raise asyncio.CancelledError("任务被用户停止")
+        return await chat_task
 
     async def run(self, prompt: str, system_prompt: str, sub_title: str) -> Any:
         """执行 Agent 对话并返回模型响应。
@@ -57,12 +85,13 @@ class Agent:
             await self.append_chat_history({"role": "system", "content": system_prompt})
             await self.append_chat_history({"role": "user", "content": prompt})
 
-            # 获取历史消息用于本次对话
-            response = await self.model.chat(
+            # 获取历史消息用于本次对话（支持取消中断）
+            response = await self._chat(
                 history=self.chat_history,
                 agent_name=self.__class__.__name__,
                 sub_title=sub_title,
             )
+
             response_content = response.content
             assistant_msg: dict = {"role": "assistant", "content": response_content}
             if response.reasoning_content:
@@ -88,6 +117,9 @@ class Agent:
 
             logger.info(f"{self.__class__.__name__}:完成:执行对话")
             return response_content
+        except asyncio.CancelledError:
+            logger.info(f"{self.__class__.__name__}:任务被用户停止")
+            raise
         except Exception as e:
             error_msg = f"执行过程中遇到错误: {str(e)}"
             logger.error(f"Agent执行失败: {str(e)}")

--- a/backend/app/core/agents/coder_agent.py
+++ b/backend/app/core/agents/coder_agent.py
@@ -1,5 +1,6 @@
 """代码手 Agent 模块，负责生成和执行 Python 代码完成建模任务。"""
 
+import asyncio
 from app.core.agents.agent import Agent
 from app.config.setting import settings, ApiType
 from app.utils.log_util import logger
@@ -30,8 +31,9 @@ class CoderAgent(Agent):
         max_retries: int | None = settings.MAX_RETRIES,  # 最大反思次数，None表示无限制
         code_interpreter: BaseCodeInterpreter | None = None,
         context_window: int = 128000,
+        cancel_event: asyncio.Event | None = None,
     ) -> None:
-        super().__init__(task_id, model, context_window)
+        super().__init__(task_id, model, context_window, cancel_event=cancel_event)
         self.work_dir = work_dir
         self.max_chat_turns = max_chat_turns
         self.current_chat_turns = 0
@@ -107,7 +109,7 @@ class CoderAgent(Agent):
             logger.info(f"当前对话轮次: {self.current_chat_turns}")
             
             try:
-                response = await self.model.chat(
+                response = await self._chat(
                     history=self.chat_history,
                     tools=tools,
                     tool_choice="auto",

--- a/backend/app/core/agents/coordinator_agent.py
+++ b/backend/app/core/agents/coordinator_agent.py
@@ -1,5 +1,6 @@
 """协调者 Agent 模块，负责识别用户意图并拆解数学建模问题。"""
 
+import asyncio
 from app.core.agents.agent import Agent
 from app.core.llm.llm import LLM
 from app.core.prompts import COORDINATOR_PROMPT
@@ -16,8 +17,9 @@ class CoordinatorAgent(Agent):
         task_id: str,
         model: LLM,
         context_window: int = 128000,
+        cancel_event: asyncio.Event | None = None,
     ) -> None:
-        super().__init__(task_id, model, context_window)
+        super().__init__(task_id, model, context_window, cancel_event=cancel_event)
         self.system_prompt = COORDINATOR_PROMPT
 
     async def run(self, ques_all: str) -> CoordinatorToModeler:  # type: ignore[reportIncompatibleMethodOverride]
@@ -36,7 +38,7 @@ class CoordinatorAgent(Agent):
         attempt = 0
         while True:
             try:
-                response = await self.model.chat(
+                response = await self._chat(
                     history=self.chat_history,
                     agent_name=self.__class__.__name__,
                 )

--- a/backend/app/core/agents/modeler_agent.py
+++ b/backend/app/core/agents/modeler_agent.py
@@ -1,5 +1,6 @@
-"""建模手 Agent 模块，负责分析问题并制定数学建模方案。"""
+"""建模手 Agent 模块，负责分析问题并制定建模方案。"""
 
+import asyncio
 from app.core.agents.agent import Agent
 from app.core.llm.llm import LLM
 from app.core.prompts import MODELER_PROMPT
@@ -58,8 +59,9 @@ class ModelerAgent(Agent):
         task_id: str,
         model: LLM,
         context_window: int = 128000,
+        cancel_event: asyncio.Event | None = None,
     ) -> None:
-        super().__init__(task_id, model, context_window)
+        super().__init__(task_id, model, context_window, cancel_event=cancel_event)
         self.system_prompt = MODELER_PROMPT
 
     async def run(self, coordinator_to_modeler: CoordinatorToModeler) -> ModelerToCoder:  # type: ignore[reportIncompatibleMethodOverride]
@@ -83,7 +85,7 @@ class ModelerAgent(Agent):
 
         attempt = 0
         while True:
-            response = await self.model.chat(
+            response = await self._chat(
                 history=self.chat_history,
                 agent_name=self.__class__.__name__,
             )

--- a/backend/app/core/agents/writer_agent.py
+++ b/backend/app/core/agents/writer_agent.py
@@ -1,5 +1,6 @@
 """写作手 Agent 模块，负责基于建模结果撰写学术论文。"""
 
+import asyncio
 from app.core.agents.agent import Agent
 from app.core.llm.llm import LLM
 from app.core.prompts import get_writer_prompt
@@ -29,8 +30,9 @@ class WriterAgent(Agent):
         format_output: FormatOutPut = FormatOutPut.Markdown,
         scholar: OpenAlexScholar | None = None,
         context_window: int = 128000,
+        cancel_event: asyncio.Event | None = None,
     ) -> None:
-        super().__init__(task_id, model, context_window)
+        super().__init__(task_id, model, context_window, cancel_event=cancel_event)
         self.format_out_put = format_output
         self.comp_template = comp_template
         self.scholar = scholar
@@ -82,7 +84,7 @@ class WriterAgent(Agent):
         await self.append_chat_history({"role": "user", "content": prompt})
 
         # 获取历史消息用于本次对话
-        response = await self.model.chat(
+        response = await self._chat(
             history=self.chat_history,
             tools=tools,
             tool_choice="auto",
@@ -149,7 +151,7 @@ class WriterAgent(Agent):
                         "name": "search_papers",
                     }
                 )
-                next_response = await self.model.chat(
+                next_response = await self._chat(
                     history=self.chat_history,
                     tools=tools,
                     tool_choice="auto",
@@ -170,7 +172,7 @@ class WriterAgent(Agent):
                 {"role": "user", "content": "请简单总结以上完成什么任务取得什么结果:"}
             )
             # 获取历史消息用于本次对话
-            response = await self.model.chat(
+            response = await self._chat(
                 history=self.chat_history, agent_name=self.__class__.__name__
             )
             response_content = response.content or ""

--- a/backend/app/core/workflow.py
+++ b/backend/app/core/workflow.py
@@ -1,5 +1,6 @@
 """工作流模块，编排多 Agent 协作完成数学建模任务。"""
 
+import asyncio
 from app.core.agents import WriterAgent, CoderAgent, CoordinatorAgent, ModelerAgent
 from app.schemas.request import Problem
 from app.schemas.response import SystemMessage
@@ -34,6 +35,16 @@ class MathModelWorkFlow(WorkFlow):
     work_dir: str  # worklow work dir
     ques_count: int = 0  # 问题数量
     questions: dict[str, str | int] = {}  # 问题
+    cancel_event: asyncio.Event | None = None  # 取消信号
+
+    async def _check_cancelled(self) -> None:
+        """检查是否收到取消信号，若已取消则发布通知并抛出 CancelledError。"""
+        if self.cancel_event and self.cancel_event.is_set():
+            await redis_manager.publish_message(
+                self.task_id,
+                SystemMessage(content="任务已停止", type="warning"),
+            )
+            raise asyncio.CancelledError("任务被用户停止")
 
     async def execute(self, problem: Problem):  # type: ignore[reportIncompatibleMethodOverride]
         """执行数学建模工作流。
@@ -50,12 +61,15 @@ class MathModelWorkFlow(WorkFlow):
         coordinator_agent = CoordinatorAgent(
             self.task_id, coordinator_llm,
             context_window=settings.COORDINATOR_CONTEXT_WINDOW,
+            cancel_event=self.cancel_event,
         )
 
         await redis_manager.publish_message(
             self.task_id,
             SystemMessage(content="识别用户意图和拆解问题ing..."),
         )
+
+        await self._check_cancelled()
 
         try:
             coordinator_response = await coordinator_agent.run(problem.ques_all)
@@ -76,9 +90,12 @@ class MathModelWorkFlow(WorkFlow):
             SystemMessage(content="建模手开始建模ing..."),
         )
 
+        await self._check_cancelled()
+
         modeler_agent = ModelerAgent(
             self.task_id, modeler_llm,
             context_window=settings.MODELER_CONTEXT_WINDOW,
+            cancel_event=self.cancel_event,
         )
 
         modeler_response = await modeler_agent.run(coordinator_response)
@@ -125,6 +142,7 @@ class MathModelWorkFlow(WorkFlow):
             max_retries=settings.MAX_RETRIES,
             code_interpreter=code_interpreter,
             context_window=settings.CODER_CONTEXT_WINDOW,
+            cancel_event=self.cancel_event,
         )
 
         writer_agent = WriterAgent(
@@ -134,6 +152,7 @@ class MathModelWorkFlow(WorkFlow):
             format_output=problem.format_output,
             scholar=scholar,
             context_window=settings.WRITER_CONTEXT_WINDOW,
+            cancel_event=self.cancel_event,
         )
 
         flows = Flows(self.questions)
@@ -143,6 +162,8 @@ class MathModelWorkFlow(WorkFlow):
         config_template = get_config_template(problem.comp_template)
 
         for key, value in solution_flows.items():
+            await self._check_cancelled()
+
             await redis_manager.publish_message(
                 self.task_id,
                 SystemMessage(content=f"代码手开始求解{key}"),
@@ -191,6 +212,8 @@ class MathModelWorkFlow(WorkFlow):
             user_output, config_template, problem.ques_all
         )
         for key, value in write_flows.items():
+            await self._check_cancelled()
+
             await redis_manager.publish_message(
                 self.task_id,
                 SystemMessage(content=f"论文手开始写{key}部分"),

--- a/backend/app/routers/modeling_router.py
+++ b/backend/app/routers/modeling_router.py
@@ -15,6 +15,7 @@ from app.utils.common_utils import (
 )
 import os
 import asyncio
+from typing import Dict, Tuple
 from fastapi import HTTPException
 from icecream import ic  # type: ignore[import-unresolved]
 from app.schemas.request import ExampleRequest
@@ -27,6 +28,9 @@ from app.core.llm.providers.base import BaseProvider
 import requests
 
 router = APIRouter()
+
+# 任务注册表: task_id -> (asyncio.Task, asyncio.Event)
+_active_tasks: Dict[str, Tuple[asyncio.Task, asyncio.Event]] = {}
 
 
 class ValidateApiKeyRequest(BaseModel):
@@ -291,6 +295,9 @@ async def run_modeling_task_async(
         format_output=format_output,
     )
 
+    # 创建取消信号
+    cancel_event = asyncio.Event()
+
     # 发送任务开始状态
     await redis_manager.publish_message(
         task_id,
@@ -300,15 +307,64 @@ async def run_modeling_task_async(
     # 给一个短暂的延迟，确保 WebSocket 有机会连接
     await asyncio.sleep(1)
 
-    # 创建任务并等待它完成
-    task = asyncio.create_task(MathModelWorkFlow().execute(problem))
-    # 设置超时时间（比如 300 分钟）
-    await asyncio.wait_for(task, timeout=3600 * 5)
+    # 创建工作流并传入取消事件
+    workflow = MathModelWorkFlow()
+    workflow.cancel_event = cancel_event
 
-    # 发送任务完成状态
-    await redis_manager.publish_message(
-        task_id,
-        SystemMessage(content="任务处理完成", type="success"),
+    # 创建任务并注册到全局表
+    task = asyncio.create_task(workflow.execute(problem))
+    _active_tasks[task_id] = (task, cancel_event)
+
+    task_completed = False
+    try:
+        # 设置超时时间（5 小时）
+        await asyncio.wait_for(task, timeout=3600 * 5)
+        task_completed = True
+
+        # 发送任务完成状态
+        await redis_manager.publish_message(
+            task_id,
+            SystemMessage(content="任务处理完成", type="success"),
+        )
+    except asyncio.CancelledError:
+        logger.info(f"任务 {task_id} 被取消")
+        await redis_manager.publish_message(
+            task_id,
+            SystemMessage(content="任务已停止", type="warning"),
+        )
+    except Exception as e:
+        logger.error(f"任务 {task_id} 执行失败: {e}")
+        await redis_manager.publish_message(
+            task_id,
+            SystemMessage(content=f"任务执行失败: {str(e)}", type="error"),
+        )
+    finally:
+        # 从注册表中清理
+        _active_tasks.pop(task_id, None)
+        # 仅在正常完成时转换 md 为 docx
+        if task_completed:
+            md_2_docx(task_id)
+
+
+class CancelTaskResponse(BaseModel):
+    success: bool
+    message: str
+
+
+@router.post("/modeling/{task_id}/cancel", response_model=CancelTaskResponse)
+async def cancel_task(task_id: str):
+    """取消正在运行的任务。"""
+    if task_id not in _active_tasks:
+        return CancelTaskResponse(
+            success=False,
+            message="任务不存在或已完成",
+        )
+
+    _, cancel_event = _active_tasks[task_id]
+    cancel_event.set()
+    logger.info(f"已发送取消信号给任务 {task_id}")
+
+    return CancelTaskResponse(
+        success=True,
+        message="停止指令已发送",
     )
-    # 转换md为docx
-    md_2_docx(task_id)

--- a/frontend/src/apis/commonApi.ts
+++ b/frontend/src/apis/commonApi.ts
@@ -57,3 +57,13 @@ export function getServiceStatus() {
 		redis: { status: string; message: string };
 	}>("/status");
 }
+
+/**
+ * 取消正在运行的任务
+ * @param task_id 任务ID
+ */
+export function cancelTask(task_id: string) {
+	return request.post<{ success: boolean; message: string }>(
+		`/modeling/${task_id}/cancel`,
+	);
+}

--- a/frontend/src/pages/task/index.vue
+++ b/frontend/src/pages/task/index.vue
@@ -50,11 +50,21 @@ const formatDuration = (ms: number): string => {
 /** 运行时长显示值 */
 const runningDuration = ref<string>("0s");
 
+/** 是否正在请求停止 */
+const isStopping = ref(false);
+
 /** 更新运行时长 */
 const updateDuration = () => {
 	currentTime.value = Date.now();
 	runningDuration.value = formatDuration(currentTime.value - startTime.value);
 };
+
+/** 处理停止运行 */
+async function handleStop() {
+	isStopping.value = true;
+	await taskStore.stopTask(props.task_id);
+	isStopping.value = false;
+}
 
 // ---- Lifecycle Hooks ----
 
@@ -128,6 +138,14 @@ onBeforeUnmount(() => {
               <!--  TODO: 其他选项 -->
 
               <div class="flex justify-end gap-2 items-center">
+                <Button
+                  v-if="taskStore.isRunning"
+                  variant="destructive"
+                  :disabled="isStopping"
+                  @click="handleStop"
+                >
+                  {{ isStopping ? "停止中..." : "停止运行" }}
+                </Button>
                 <Button @click="taskStore.downloadMessages" class="flex justify-end">
                   下载消息
                 </Button>

--- a/frontend/src/stores/task.ts
+++ b/frontend/src/stores/task.ts
@@ -1,4 +1,5 @@
 import { getTaskMessages } from "@/apis/commonApi";
+import { cancelTask as cancelTaskAPI } from "@/apis/commonApi";
 import { AgentType } from "@/utils/enum";
 import type {
 	CoderMessage,
@@ -40,6 +41,9 @@ export const useTaskStore = defineStore("task", () => {
 	const wsStatus = ref<
 		"connecting" | "connected" | "disconnected" | "reconnecting"
 	>("disconnected");
+
+	/** 任务是否正在运行 */
+	const isRunning = ref(false);
 
 	// ---- Helpers ----
 
@@ -147,6 +151,7 @@ export const useTaskStore = defineStore("task", () => {
 		}
 		setCurrentTask(taskId);
 		ensureTaskBucket(taskId);
+		isRunning.value = true;
 
 		const baseUrl = import.meta.env.VITE_WS_URL;
 		const wsUrl = `${baseUrl}/task/${taskId}`;
@@ -159,13 +164,22 @@ export const useTaskStore = defineStore("task", () => {
 					return;
 				}
 				appendMessage(taskId, data);
+				// 检测任务完成/停止/失败消息
+				if (data.msg_type === "system") {
+					const msgType = Reflect.get(data, "type");
+					if (
+						msgType === "success" ||
+						msgType === "warning" ||
+						msgType === "error"
+					) {
+						isRunning.value = false;
+					}
+				}
 			},
 			(status) => {
 				wsStatus.value = status;
 			},
 		);
-		// 初始化测试数据（已在上面初始化，这里可以注释掉）
-		// messages.value = messageData as Message[]
 		ws.connect();
 	}
 
@@ -186,6 +200,20 @@ export const useTaskStore = defineStore("task", () => {
 	function closeWebSocket() {
 		ws?.close();
 		ws = null;
+	}
+
+	/** 取消正在运行的任务 */
+	async function stopTask(taskId: string) {
+		try {
+			const res = await cancelTaskAPI(taskId);
+			if (res.data.success) {
+				isRunning.value = false;
+			}
+			return res.data;
+		} catch (error) {
+			console.error("取消任务失败:", error);
+			return { success: false, message: "取消请求失败" };
+		}
 	}
 
 	/** 添加用户消息 */
@@ -315,6 +343,7 @@ export const useTaskStore = defineStore("task", () => {
 	return {
 		messages,
 		wsStatus,
+		isRunning,
 		chatMessages,
 		coordinatorMessages,
 		modelerMessages,
@@ -325,6 +354,7 @@ export const useTaskStore = defineStore("task", () => {
 		loadTaskMessages,
 		connectWebSocket,
 		closeWebSocket,
+		stopTask,
 		downloadMessages,
 		addUserMessage,
 	};


### PR DESCRIPTION
## 描述
为任务详情页面添加"停止运行"按钮，支持用户在任务执行过程中主动中止任务。

### 改动内容

**后端**
- 新增 `POST /modeling/{task_id}/cancel` 取消接口
- 实现 `asyncio.Event` 取消机制，支持中断 LLM 调用

**前端**
- 添加 `cancelTask()` API 调用
- 任务详情页添加"停止运行"按钮（红色破坏性样式）

### 修复问题
- 修复任务取消后仍尝试调用 `md_2_docx()` 的错误（RuntimeError）