### PR TITLE
docs(readme): 修正 README 功能状态标记并优化部署文档结构

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,20 @@
 - [x] 添加正确文献引用
 - [x] 更多测试案例
 - [x] docker 部署
-- [x] human in loop ( HIL ): 关键节点暂停等待用户审批，支持 6 种决策动作（confirm/edit/regenerate/ask/skip/abort）
-- [x] feedback: 评估器评分 + 反馈注入重跑，先 Writer 后 Coder
+- [~] human in loop ( HIL ): 关键节点暂停等待用户审批，支持 6 种决策动作（confirm/edit/regenerate/ask/skip/abort）
+  <!-- TODO: 数据模型已实现，但工作流集成不完整 -->
+- [] feedback: 评估器评分 + 反馈注入重跑，先 Writer 后 Coder
+  <!-- TODO: 核心逻辑未实现，仅有 Agent 基类中的 TODO 注释 -->
 - [x] codeinterpreter 接入云端 如 e2b 等供应商..
 - [ ] 多语言: R 语言, matlab
 - [ ] 绘图 napki,draw.io,plantuml,svg, mermaid.js
 - [ ] 添加 benchmark
-- [x] web search tool: Tavily API 搜索互联网获取真实数据
-- [x] RAG 知识库: ChromaDB + Rerank 检索建模方法、代码模板、论文写作参考
-- [x] A2A hand off: Fallback 自动切换备用模型 + 有限重试 + Evaluator Shadow Mode
+- [~] web search tool: Tavily API 搜索互联网获取真实数据
+  <!-- NOTE: 原计划 Tavily API 未实现，当前使用 OpenAlex 替代 -->
+- [ ] RAG 知识库: ChromaDB + Rerank 检索建模方法、代码模板、论文写作参考
+  <!-- TODO: 仅配置项存在，核心检索逻辑未实现 -->
+- [ ] A2A hand off: Fallback 自动切换备用模型 + 有限重试 + Evaluator Shadow Mode
+  <!-- TODO: 配置项和核心逻辑均未实现，仅有基础重试机制 -->
 - [ ] chat / agent mode
 
 ## 视频demo
@@ -111,18 +116,26 @@ docker-compose up
 
 侧边栏 -> 头像 -> API Key
 
-
-### 💻 方案二: 本地部署
+### 💻 方案二: 本地部署（推荐项目开发者部署）
 
 > 确保电脑中安装好 Python, Nodejs, **Redis** 环境
 
 
-1. 安装依赖
 
-启动后端
+# 安装依赖
 
-> [!CAUTION]
-> 启动 Redis, 下载和运行问 AI
+## 1.下载并启动Redis
+
+下载Redis
+
+- windows 下载地址：<https://github.com/tporadowski/redis/releases>
+- linux or mac 下载地址：<https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/>
+
+```bash
+redis-server
+```
+
+## 2.启动后端
 
 ```bash
 # ============ 安装依赖 ============
@@ -150,13 +163,15 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws-ping-interval 60 --ws-ping-
 # 1. 设置环境变量
 $env:ENV="DEV"
 $env:REDIS_URL="redis://localhost:6379/0"
-# 2. 激活虚拟环境（使用 PowerShell 专用脚本）
+# 2. 设置 PowerShell 执行策略策略为 RemoteSigned
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+# 3. 激活虚拟环境（使用 PowerShell 专用脚本）
 . .\.venv\Scripts\Activate.ps1
-# 3. 启动后端服务（激活后命令行提示符会显示 (backend)）
+# 4. 启动后端服务（激活后命令行提示符会显示 (backend)）
 uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws-ping-interval 60 --ws-ping-timeout 120 --reload
 ```
 
-启动前端
+## 3.启动前端
 
 ```bash
 cd frontend # 切换到 frontend 目录下
@@ -278,16 +293,26 @@ Thanks to the following projects:
 > [!CAUTION]
 > 免责声明: 注意，AI 生成仅供参考，目前水平直接参加国赛获奖是不可能的，但我相信 AI 和 该项目未来的成长。
 
+# 启动项目：
 
-如何启动：
-# 启动 Redis（如果没在运行）
+## 1.启动 Redis
+
+```bash
 redis-server
+```
 
-# 启动后端
-cd D:\MathModelAgent\backend
-$env:ENV = "DEV"; $env:REDIS_URL = "redis://localhost:6379/0"
-.venv\Scripts\uvicorn.exe app.main:app --host 0.0.0.0 --port 8000 --ws-ping-interval 60 --ws-ping-timeout 120
+## 2.启动后端
 
-# 启动前端（另一个终端）
-cd D:\MathModelAgent\frontend
+```bash
+cd .\backend\
+. .\.venv\Scripts\Activate.ps1
+uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws-ping-interval 60 --ws-ping-timeout 120 --reload
+```
+
+## 3.启动前端
+
+```bash
+cd .\frontend\
 pnpm run dev
+```
+


### PR DESCRIPTION
1. 将 5 个未实现/半成品功能从 [x] 改为准确状态:
  - [ ] HIL 人机协作: 数据模型已实现但工作流集成不完整
  - [ ] Feedback 评估器+反馈重跑: 核心逻辑未实现,仅有 TODO 注释
  - [ ] Web Search: 原计划 Tavily API 未实现,当前使用 OpenAlex 替代
  - [ ] RAG 知识库: 仅配置项存在,核心检索逻辑未实现
  - [ ] Fallback Hand Off: 配置项和备用模型切换逻辑均未实现

2. 重构本地部署文档:
  - 拆分为清晰的章节结构(下载Redis/启动后端/启动前端)
  - 补充 Redis 官方下载链接(windows/linux/mac)
  - 新增 PowerShell 执行策略配置步骤(Set-ExecutionPolicy)
  - 统一底部启动指南格式,移除硬编码绝对路径