### PR TITLE
fix+perf: 绘图中文字体修复、进度自动跟踪、未验证配置刷爆日志

### DIFF
--- a/backend/app/core/agents/coordinator_agent.py
+++ b/backend/app/core/agents/coordinator_agent.py
@@ -9,6 +9,8 @@ import re
 from app.utils.log_util import logger
 from app.schemas.A2A import CoordinatorToModeler
 
+MAX_JSON_RETRIES = 3
+
 
 class CoordinatorAgent(Agent):
     """协调者 Agent，判断用户输入是否为数学建模问题并拆解为结构化问题列表。"""
@@ -36,7 +38,8 @@ class CoordinatorAgent(Agent):
         )
         await self.append_chat_history({"role": "user", "content": ques_all})
         attempt = 0
-        while True:
+        last_error: Exception | None = None
+        while attempt < MAX_JSON_RETRIES:
             try:
                 response = await self._chat(
                     history=self.chat_history,
@@ -58,7 +61,8 @@ class CoordinatorAgent(Agent):
 
             except (json.JSONDecodeError, ValueError, KeyError) as e:
                 attempt += 1
-                logger.warning(f"解析失败 (尝试 {attempt}): {str(e)}")
+                last_error = e
+                logger.warning(f"解析失败 (尝试 {attempt}/{MAX_JSON_RETRIES}): {str(e)}")
 
                 # 添加错误反馈提示
                 error_prompt = f"⚠️ 上次响应格式错误: {str(e)}。请严格输出JSON格式"
@@ -66,3 +70,5 @@ class CoordinatorAgent(Agent):
                     "role": "system",
                     "content": self.system_prompt + "\n" + error_prompt
                 })
+
+        raise last_error or ValueError("CoordinatorAgent JSON 解析重试次数耗尽")

--- a/backend/app/core/agents/modeler_agent.py
+++ b/backend/app/core/agents/modeler_agent.py
@@ -10,6 +10,8 @@ import json
 import re
 from icecream import ic  # type: ignore[import-unresolved]
 
+MAX_JSON_RETRIES = 3
+
 
 def repair_json(json_str: str) -> dict | None:
     """尝试修复 LLM 输出的格式错误的 JSON。
@@ -84,7 +86,7 @@ class ModelerAgent(Agent):
         )
 
         attempt = 0
-        while True:
+        while attempt < MAX_JSON_RETRIES:
             response = await self._chat(
                 history=self.chat_history,
                 agent_name=self.__class__.__name__,
@@ -101,7 +103,7 @@ class ModelerAgent(Agent):
 
             attempt += 1
             logger.warning(
-                f"JSON 解析失败 (第{attempt}次)，请求模型重新生成"
+                f"JSON 解析失败 (第{attempt}/{MAX_JSON_RETRIES}次)，请求模型重新生成"
             )
             retry_msg: dict = {"role": "assistant", "content": json_str}
             if response.reasoning_content:
@@ -113,3 +115,5 @@ class ModelerAgent(Agent):
                     "content": "你返回的JSON格式有误，请严格按照JSON格式重新输出，注意字符串值内的双引号必须转义为\\\"，不要包含未转义的特殊字符。",
                 }
             )
+
+        raise ValueError("ModelerAgent JSON 解析重试次数耗尽")

--- a/backend/app/core/llm/llm.py
+++ b/backend/app/core/llm/llm.py
@@ -21,6 +21,10 @@ from app.core.llm.providers.openai_responses import OpenAIResponsesProvider
 from app.core.llm.providers.anthropic import AnthropicProvider
 
 
+class LLMConfigError(RuntimeError):
+    """LLM 配置缺失时抛出，与 JSON 解析的 ValueError 区分开，避免被重试循环误捕获。"""
+
+
 class LLM:
     """大语言模型封装类，提供对话调用、重试和工具调用验证功能。"""
 
@@ -56,9 +60,9 @@ class LLM:
     def _validate_config(self, agent_name: str) -> None:
         """验证 LLM 配置是否完整。"""
         if not self.model or not str(self.model).strip():
-            raise ValueError(f"{agent_name} 未配置模型 ID，请设置对应的 *_MODEL")
+            raise LLMConfigError(f"{agent_name} 未配置模型 ID，请设置对应的 *_MODEL")
         if not self.api_key or not str(self.api_key).strip():
-            raise ValueError(f"{agent_name} 未配置 API Key，请设置对应的 *_API_KEY")
+            raise LLMConfigError(f"{agent_name} 未配置 API Key，请设置对应的 *_API_KEY")
 
     async def chat(
         self,

--- a/backend/app/core/prompts/coder.py
+++ b/backend/app/core/prompts/coder.py
@@ -76,44 +76,22 @@ df['\\u5a74\\u513f\\u884c\\u4e3a\\u7279\\u5f81']  # No unicode escapes
 
 # 可视化规范（学术论文标准）
 
-## 全局配置（每个 notebook 开头必须设置）
+## 执行环境预配置（禁止重复设置）
+代码沙盒启动时已注入：`CJK_FONT`、`COLORS`、`DEFAULT_COLORS`、`FIG_SINGLE`、`FIG_DOUBLE`、`FIG_WIDE`、`FIG_SQUARE`，以及字体与 matplotlib 样式 rcParams。
+
+**严格禁止**在代码中调用 `sns.set_theme()` 或修改 `font.*` / `font.sans-serif` / `axes.unicode_minus`（否则会覆盖中文字体导致方框）。
+
+绑图时直接使用预置变量，示例：
 ```python
 import matplotlib.pyplot as plt
 import seaborn as sns
-sns.set_theme(style='ticks')
 
-plt.rcParams.update({{
-    'font.family': 'sans-serif',
-    'font.size': 11,
-    'axes.titlesize': 12,
-    'axes.titleweight': 'bold',
-    'axes.labelsize': 11,
-    'axes.linewidth': 1.2,
-    'axes.spines.top': False,
-    'axes.spines.right': False,
-    'xtick.labelsize': 10,
-    'ytick.labelsize': 10,
-    'legend.fontsize': 10,
-    'legend.frameon': False,
-    'figure.dpi': 300,
-    'savefig.dpi': 300,
-    'savefig.bbox': 'tight',
-    'savefig.pad_inches': 0.1,
-}})
-plt.rcParams['font.sans-serif'] = ['SimHei', 'Noto Sans CJK SC', 'Noto Sans SC', 'DejaVu Sans']
-plt.rcParams['axes.unicode_minus'] = False
-
-COLORS = {{
-    'primary': '#2E5B88',
-    'secondary': '#E85D4C',
-    'tertiary': '#4A9B7F',
-    'neutral': '#7F7F7F',
-    'light': '#B8D4E8',
-}}
-FIG_SINGLE = (5, 4)
-FIG_DOUBLE = (10, 4)
-FIG_WIDE = (8, 3)
-FIG_SQUARE = (6, 6)
+fig, ax = plt.subplots(figsize=FIG_SINGLE)
+sns.lineplot(x=x, y=y, ax=ax, color=COLORS['primary'])
+ax.set_xlabel('时间 (月)')
+ax.set_ylabel('产量 (吨)')
+plt.savefig('trend.png', dpi=300, bbox_inches='tight')
+plt.close()
 ```
 
 ## 图表类型选择

--- a/backend/app/core/workflow.py
+++ b/backend/app/core/workflow.py
@@ -55,6 +55,21 @@ class MathModelWorkFlow(WorkFlow):
         self.task_id = problem.task_id
         self.work_dir = create_work_dir(self.task_id)
 
+        # 在创建 LLM 前预校验配置，避免进入 Agent 循环后才发现缺配置
+        missing = []
+        for name, model_val, key_val in [
+            ("Coordinator", settings.COORDINATOR_MODEL, settings.COORDINATOR_API_KEY),
+            ("Modeler", settings.MODELER_MODEL, settings.MODELER_API_KEY),
+            ("Coder", settings.CODER_MODEL, settings.CODER_API_KEY),
+            ("Writer", settings.WRITER_MODEL, settings.WRITER_API_KEY),
+        ]:
+            if not model_val or not str(model_val).strip():
+                missing.append(f"{name} 模型 ID")
+            if not key_val or not str(key_val).strip():
+                missing.append(f"{name} API Key")
+        if missing:
+            raise ValueError(f"以下配置缺失，请先在设置中填写并保存：{', '.join(missing)}")
+
         llm_factory = LLMFactory(self.task_id)
         coordinator_llm, modeler_llm, coder_llm, writer_llm = llm_factory.get_all_llms()
 

--- a/backend/app/tools/local_interpreter.py
+++ b/backend/app/tools/local_interpreter.py
@@ -1,6 +1,7 @@
 """本地代码解释器模块，通过本地 Jupyter 内核执行 Python 代码。"""
 
 from app.tools.base_interpreter import BaseCodeInterpreter
+from app.tools.matplotlib_setup import build_matplotlib_init_code
 from app.tools.notebook_serializer import NotebookSerializer
 import jupyter_client
 from app.utils.log_util import logger
@@ -40,35 +41,7 @@ class LocalCodeInterpreter(BaseCodeInterpreter):
         self._pre_execute_code()
 
     def _pre_execute_code(self):
-        init_code = (
-            f"import os\n"
-            f"work_dir = r'{self.work_dir}'\n"
-            f"os.makedirs(work_dir, exist_ok=True)\n"
-            f"os.chdir(work_dir)\n"
-            f"print('当前工作目录:', os.getcwd())\n"
-            # 加载中文字体，确保图表中文正常显示（跨平台兼容）
-            # 先清除 matplotlib 字体缓存，避免旧缓存导致 addfont 失效
-            f"import matplotlib\n"
-            f"import matplotlib.pyplot as plt\n"
-            f"from matplotlib import font_manager\n"
-            f"import glob as _glob, pathlib as _pl\n"
-            f"_cache_dir = _pl.Path(matplotlib.get_cachedir())\n"
-            f"for _cache_file in _glob.glob(str(_cache_dir / 'fontlist*.json')):\n"
-            f"    _pl.Path(_cache_file).unlink(missing_ok=True)\n"
-            f"font_manager.fontManager.__init__()\n"
-            f"_font_dir = work_dir\n"
-            f"_loaded = False\n"
-            f"for _f in os.listdir(_font_dir):\n"
-            f"    if _f.lower().endswith(('.ttf', '.otf', '.ttc')):\n"
-            f"        _fp = os.path.join(_font_dir, _f)\n"
-            f"        font_manager.fontManager.addfont(_fp)\n"
-            f"        _loaded = True\n"
-            f"if _loaded:\n"
-            f"    print(f'中文字体已加载，可用字体数: {{len(font_manager.fontManager.ttflist)}}')\n"
-            f"plt.rcParams['font.sans-serif'] = ['SimHei', 'Heiti SC', 'STHeiti', 'PingFang SC', 'Noto Sans CJK SC', 'Noto Sans SC', 'WenQuanYi Micro Hei', 'Microsoft YaHei', 'sans-serif']\n"
-            f"plt.rcParams['axes.unicode_minus'] = False\n"
-            f"plt.rcParams['font.family'] = 'sans-serif'\n"
-        )
+        init_code = build_matplotlib_init_code(self.work_dir)
         self.execute_code_(init_code)
 
     async def execute_code(self, code: str) -> tuple[str, bool, str]:

--- a/backend/app/tools/local_interpreter.py
+++ b/backend/app/tools/local_interpreter.py
@@ -38,11 +38,32 @@ class LocalCodeInterpreter(BaseCodeInterpreter):
         self.km, self.kc = jupyter_client.manager.start_new_kernel(
             kernel_name="python3", env=kernel_env
         )
-        self._pre_execute_code()
+        font_msg, font_type = self._pre_execute_code()
+        if font_msg:
+            await redis_manager.publish_message(
+                self.task_id,
+                SystemMessage(content=font_msg, type=font_type),
+            )
 
-    def _pre_execute_code(self):
+    def _pre_execute_code(self) -> tuple[str | None, str]:
+        """执行 matplotlib 初始化，并解析字体加载结果供前端展示。
+
+        Returns:
+            (消息文案, SystemMessage.type)；无可用信息时文案为 None。
+        """
         init_code = build_matplotlib_init_code(self.work_dir)
-        self.execute_code_(init_code)
+        execution = self.execute_code_(init_code)
+        stdout = "\n".join(text for mark, text in execution if mark == "stdout")
+        for line in stdout.splitlines():
+            line = line.strip()
+            if "中文字体已加载" in line:
+                # 去掉日志前缀，前端只展示关键结论
+                content = line.removeprefix("[matplotlib_setup] ").strip()
+                return content, "success"
+            if "未找到中文字体" in line:
+                content = line.removeprefix("[matplotlib_setup] ").strip()
+                return content, "warning"
+        return None, "info"
 
     async def execute_code(self, code: str) -> tuple[str, bool, str]:
         logger.info(f"执行代码: {code}")

--- a/backend/app/tools/matplotlib_setup.py
+++ b/backend/app/tools/matplotlib_setup.py
@@ -1,0 +1,108 @@
+"""Matplotlib 引导脚本，供本地/E2B 解释器在 kernel 启动时注入字体与绘图常量。"""
+
+from __future__ import annotations
+
+# 竞赛向配色（与 CODER_PROMPT 保持同名，阶段 3 可在此统一调整）
+COLORS: dict[str, str] = {
+    "primary": "#2E5B88",
+    "secondary": "#E85D4C",
+    "tertiary": "#4A9B7F",
+    "neutral": "#7F7F7F",
+    "light": "#B8D4E8",
+}
+
+FIG_SINGLE = (5, 4)
+FIG_DOUBLE = (10, 4)
+FIG_WIDE = (8, 3)
+FIG_SQUARE = (6, 6)
+
+
+def build_matplotlib_init_code(
+    work_dir: str,
+    *,
+    font_dir: str | None = None,
+    setup_chdir: bool = True,
+) -> str:
+    """生成在 Jupyter/E2B kernel 中执行的 matplotlib 初始化代码。
+
+    Args:
+        work_dir: 任务工作目录（本地解释器用于 chdir）。
+        font_dir: 字体文件目录，默认与 work_dir 相同。
+        setup_chdir: 是否切换到 work_dir。
+
+    Returns:
+        可在 kernel 中执行的 Python 代码字符串。
+    """
+    font_dir = font_dir or work_dir
+    colors_repr = repr(COLORS)
+    fig_single = repr(FIG_SINGLE)
+    fig_double = repr(FIG_DOUBLE)
+    fig_wide = repr(FIG_WIDE)
+    fig_square = repr(FIG_SQUARE)
+
+    chdir_block = ""
+    if setup_chdir:
+        chdir_block = (
+            f"import os\n"
+            f"work_dir = r'{work_dir}'\n"
+            f"os.makedirs(work_dir, exist_ok=True)\n"
+            f"os.chdir(work_dir)\n"
+            f"print('[matplotlib_setup] 当前工作目录:', os.getcwd())\n"
+        )
+    else:
+        chdir_block = "import os\n"
+
+    return (
+        chdir_block
+        + "import matplotlib\n"
+        + "import matplotlib.pyplot as plt\n"
+        + "from matplotlib import font_manager\n"
+        + "import glob as _glob, pathlib as _pl\n"
+        + f"_font_dir = r'{font_dir}'\n"
+        + "_cache_dir = _pl.Path(matplotlib.get_cachedir())\n"
+        + "for _cache_file in _glob.glob(str(_cache_dir / 'fontlist*.json')):\n"
+        + "    _pl.Path(_cache_file).unlink(missing_ok=True)\n"
+        + "font_manager.fontManager.__init__()\n"
+        + "_cjk_fonts = []\n"
+        + "for _f in os.listdir(_font_dir):\n"
+        + "    if _f.lower().endswith(('.ttf', '.otf', '.ttc')):\n"
+        + "        _fp = os.path.join(_font_dir, _f)\n"
+        + "        font_manager.fontManager.addfont(_fp)\n"
+        + "        _name = font_manager.FontProperties(fname=_fp).get_name()\n"
+        + "        if _name not in _cjk_fonts:\n"
+        + "            _cjk_fonts.append(_name)\n"
+        + "if _cjk_fonts:\n"
+        + "    CJK_FONT = _cjk_fonts[0]\n"
+        + "    _fallback = ['Heiti SC', 'STHeiti', 'PingFang SC', 'Noto Sans CJK SC', 'Noto Sans SC', 'WenQuanYi Micro Hei', 'Microsoft YaHei', 'sans-serif']\n"
+        + "    plt.rcParams['font.sans-serif'] = _cjk_fonts + [f for f in _fallback if f not in _cjk_fonts]\n"
+        + "    plt.rcParams['axes.unicode_minus'] = False\n"
+        + "    plt.rcParams['font.family'] = 'sans-serif'\n"
+        + "    print(f'[matplotlib_setup] 中文字体已加载: {CJK_FONT} (共 {len(_cjk_fonts)} 个)')\n"
+        + "else:\n"
+        + "    CJK_FONT = None\n"
+        + "    print('[matplotlib_setup] 警告: 未找到中文字体文件，中文标签可能显示为方框')\n"
+        + "plt.rcParams.update({\n"
+        + "    'font.size': 11,\n"
+        + "    'axes.titlesize': 12,\n"
+        + "    'axes.titleweight': 'bold',\n"
+        + "    'axes.labelsize': 11,\n"
+        + "    'axes.linewidth': 1.2,\n"
+        + "    'axes.spines.top': False,\n"
+        + "    'axes.spines.right': False,\n"
+        + "    'xtick.labelsize': 10,\n"
+        + "    'ytick.labelsize': 10,\n"
+        + "    'legend.fontsize': 10,\n"
+        + "    'legend.frameon': False,\n"
+        + "    'figure.dpi': 300,\n"
+        + "    'savefig.dpi': 300,\n"
+        + "    'savefig.bbox': 'tight',\n"
+        + "    'savefig.pad_inches': 0.1,\n"
+        + "})\n"
+        + f"COLORS = {colors_repr}\n"
+        + "DEFAULT_COLORS = list(COLORS.values())\n"
+        + f"FIG_SINGLE = {fig_single}\n"
+        + f"FIG_DOUBLE = {fig_double}\n"
+        + f"FIG_WIDE = {fig_wide}\n"
+        + f"FIG_SQUARE = {fig_square}\n"
+        + "print('[matplotlib_setup] 绘图环境就绪 (COLORS, FIG_* 已注入)')\n"
+    )

--- a/backend/app/tools/matplotlib_setup.py
+++ b/backend/app/tools/matplotlib_setup.py
@@ -40,17 +40,18 @@ def build_matplotlib_init_code(
     fig_wide = repr(FIG_WIDE)
     fig_square = repr(FIG_SQUARE)
 
-    chdir_block = ""
+    # 必须先解析为绝对路径：相对 work_dir 在 os.chdir 之后会导致 listdir/addfont 失败
+    chdir_block = (
+        "import os\n"
+        f"work_dir = os.path.abspath(r'{work_dir}')\n"
+        f"_font_dir = os.path.abspath(r'{font_dir}')\n"
+    )
     if setup_chdir:
-        chdir_block = (
-            f"import os\n"
-            f"work_dir = r'{work_dir}'\n"
-            f"os.makedirs(work_dir, exist_ok=True)\n"
-            f"os.chdir(work_dir)\n"
-            f"print('[matplotlib_setup] 当前工作目录:', os.getcwd())\n"
+        chdir_block += (
+            "os.makedirs(work_dir, exist_ok=True)\n"
+            "os.chdir(work_dir)\n"
+            "print('[matplotlib_setup] 当前工作目录:', os.getcwd())\n"
         )
-    else:
-        chdir_block = "import os\n"
 
     return (
         chdir_block
@@ -58,7 +59,6 @@ def build_matplotlib_init_code(
         + "import matplotlib.pyplot as plt\n"
         + "from matplotlib import font_manager\n"
         + "import glob as _glob, pathlib as _pl\n"
-        + f"_font_dir = r'{font_dir}'\n"
         + "_cache_dir = _pl.Path(matplotlib.get_cachedir())\n"
         + "for _cache_file in _glob.glob(str(_cache_dir / 'fontlist*.json')):\n"
         + "    _pl.Path(_cache_file).unlink(missing_ok=True)\n"

--- a/frontend/src/components/ChatArea.vue
+++ b/frontend/src/components/ChatArea.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useStickyScroll } from "@/composables/useStickyScroll";
 import type { Message } from "@/utils/response";
 import { Send } from "lucide-vue-next";
 import { ref } from "vue";
@@ -17,6 +18,10 @@ const inputValue = ref("");
 const inputRef = ref<HTMLInputElement | null>(null);
 const scrollRef = ref<HTMLDivElement | null>(null);
 
+// ---- Scroll ----
+
+const { onScroll } = useStickyScroll(scrollRef, () => props.messages);
+
 // ---- Methods ----
 
 /** 发送消息（本地处理） */
@@ -29,7 +34,7 @@ const sendMessage = () => {
 
 <template>
   <div class="flex h-full flex-col p-3">
-    <div ref="scrollRef" class="flex-1 overflow-y-auto">
+    <div ref="scrollRef" class="flex-1 overflow-y-auto" @scroll="onScroll">
       <template v-for="message in props.messages" :key="message.id">
         <div class="mb-3">
           <!-- 用户消息 -->

--- a/frontend/src/components/NotebookArea.vue
+++ b/frontend/src/components/NotebookArea.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import NotebookCell from "@/components/NotebookCell.vue";
+import { useStickyScroll } from "@/composables/useStickyScroll";
 import { useTaskStore } from "@/stores/task";
 import type { CodeCell, NoteCell, ResultCell } from "@/utils/interface";
-import { computed } from "vue";
+import { computed, ref } from "vue";
 
 // ---- Reactive State ----
 
 const taskStore = useTaskStore();
+const scrollRef = ref<HTMLDivElement | null>(null);
 
 // ---- Computed ----
 
@@ -39,10 +41,14 @@ const cells = computed<NoteCell[]>(() => {
 
 	return notebookCells;
 });
+
+// ---- Scroll ----
+
+const { onScroll } = useStickyScroll(scrollRef, () => cells.value);
 </script>
 
 <template>
-  <div class="flex-1 px-1 pt-1 pb-4 h-full overflow-y-auto">
+  <div ref="scrollRef" class="flex-1 px-1 pt-1 pb-4 h-full overflow-y-auto" @scroll="onScroll">
     <!-- 遍历所有单元格 -->
     <div v-for="(cell, index) in cells" :key="index" :class="[
       'transform transition-all duration-200 hover:shadow-lg',

--- a/frontend/src/composables/useStickyScroll.ts
+++ b/frontend/src/composables/useStickyScroll.ts
@@ -1,0 +1,41 @@
+import type { Ref, WatchSource } from "vue";
+import { nextTick, onMounted, ref, watch } from "vue";
+
+const STICKY_THRESHOLD = 40;
+
+/**
+ * 粘底滚动：默认跟踪最新内容，用户上翻暂停，滚回底部恢复。
+ *
+ * @param scrollRef 滚动容器的 template ref
+ * @param source 需要监听的响应式数据源（新数据到达时触发滚动）
+ */
+export function useStickyScroll(
+	scrollRef: Ref<HTMLElement | null>,
+	source: WatchSource,
+) {
+	const isPinnedToBottom = ref(true);
+
+	function scrollToBottom() {
+		const el = scrollRef.value;
+		if (el) el.scrollTop = el.scrollHeight;
+	}
+
+	function onScroll() {
+		const el = scrollRef.value;
+		if (!el) return;
+		isPinnedToBottom.value =
+			el.scrollHeight - el.scrollTop - el.clientHeight <= STICKY_THRESHOLD;
+	}
+
+	watch(
+		source,
+		() => {
+			if (isPinnedToBottom.value) nextTick(scrollToBottom);
+		},
+		{ deep: true },
+	);
+
+	onMounted(() => nextTick(scrollToBottom));
+
+	return { onScroll };
+}

--- a/frontend/src/pages/chat/components/ApiDialog.vue
+++ b/frontend/src/pages/chat/components/ApiDialog.vue
@@ -136,18 +136,16 @@ const saveToStore = async () => {
 	apiKeyStore.setCoderConfig(form.value.coder);
 	apiKeyStore.setWriterConfig(form.value.writer);
 	apiKeyStore.setOpenalexEmail(form.value.openalex_email);
-	if (allValid.value) {
-		try {
-			await saveApiConfig({
-				coordinator: form.value.coordinator,
-				modeler: form.value.modeler,
-				coder: form.value.coder,
-				writer: form.value.writer,
-				openalex_email: form.value.openalex_email,
-			});
-		} catch (error) {
-			console.error("保存配置到后端失败:", error);
-		}
+	try {
+		await saveApiConfig({
+			coordinator: form.value.coordinator,
+			modeler: form.value.modeler,
+			coder: form.value.coder,
+			writer: form.value.writer,
+			openalex_email: form.value.openalex_email,
+		});
+	} catch (error) {
+		console.error("保存配置到后端失败:", error);
 	}
 };
 


### PR DESCRIPTION
## Summary

- **fix: 加固 Docker matplotlib 中文字体配置** — 新增 `matplotlib_setup.py` 统一字体注册，绝对路径解决 chdir 后注册失败；Coder prompt 禁止模型覆盖字体 rcParams
- **fix: 未验证模型配置直接启动任务时无限重试刷爆日志** — 前端保存配置始终推后端（去掉 allValid 门控）；后端 workflow 入口预校验配置；`_validate_config` 改抛 `LLMConfigError` 隔离 JSON 重试；coordinator/modeler 加 `MAX_JSON_RETRIES=3`
- **perf: 进度时间线与代码执行区自动跟踪最新消息** — 新增 `useStickyScroll` composable，ChatArea 和 NotebookArea 粘底滚动

## Changed Files (11 files, +248 -89)

| File | Change |
|------|--------|
| `backend/app/tools/matplotlib_setup.py` | 新增：统一字体注册 + 学术绘图 rcParams |
| `backend/app/tools/local_interpreter.py` | 用 `build_matplotlib_init_code()` 替代内联字体代码 |
| `backend/app/core/prompts/coder.py` | 删除 LLM 重复设置字体/主题的 prompt，改为"已注入，禁止覆盖" |
| `backend/app/core/llm/llm.py` | 新增 `LLMConfigError`，`_validate_config` 改抛此异常 |
| `backend/app/core/workflow.py` | `execute()` 入口预校验 4 个 Agent 的 model/apiKey |
| `backend/app/core/agents/coordinator_agent.py` | JSON 解析重试加上限 `MAX_JSON_RETRIES=3` |
| `backend/app/core/agents/modeler_agent.py` | 同上 |
| `frontend/src/pages/chat/components/ApiDialog.vue` | 保存配置始终推后端，不再依赖验证通过 |
| `frontend/src/composables/useStickyScroll.ts` | 新增：粘底滚动 composable |
| `frontend/src/components/ChatArea.vue` | 接入 useStickyScroll |
| `frontend/src/components/NotebookArea.vue` | 接入 useStickyScroll |

## Test Plan

- [x] Docker 环境运行含中文标题的绘图任务，确认中文正常显示
- [x] 不点「一键验证」直接保存配置后启动任务，确认能正常运行（不再刷日志）
- [x] 未配置任何模型时启动任务，确认前端收到明确的错误提示
- [x] 任务运行中观察左侧进度时间线和右侧代码执行区，确认自动滚动到最新消息