### PR TITLE
docs: 引用 sci-box 科研图表与流程图仓库

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 <p align="center">
     <a href="https://github.com/jihe520/MathModelAgent/releases/latest"><b>⬇️ 下载最新桌面版（推荐）</b></a>
 </p>
+<p align="center">
+    🎨 姊妹项目：<a href="https://github.com/jihe520/sci-box"><b>sci-box</b></a> —— 科研图表 & 流程图 SKILL 合集
+</p>
 
 ---
 
@@ -107,7 +110,18 @@ MathModelAgent SKILL —— 直接在 Harness 中驱动的数学建模自动化�
 **🔧 可组合、可扩展**
 每个阶段是独立 Skill，可单独调用（如只跑分析、只写论文）；模板和知识库可自由扩展；支持 Typst 生态排版。
 
-skills 中包含一个科研绘图模板skill,可以绘制一些炫酷的科研图表
+### 🎨 姊妹项目：sci-box（科研图表 & 流程图）
+
+科研绘图和流程图模板已独立成仓库 **[jihe520/sci-box](https://github.com/jihe520/sci-box)**，可单独安装、单独使用：
+
+| SKILL | 内容 |
+|-------|------|
+| `scibox-figure` | SHAP / ROC / Taylor / 云雨图 / 和弦图 / 环形热图等科研图表复刻模板（Python + Matplotlib，导出 PNG / PDF / SVG） |
+| `scibox-diagram` | 可编辑的 draw.io 模板：五层技术路线图、三栏研究框架、三栏流程图、横向任务流水线 |
+
+```
+npx skills add jihe520/sci-box
+```
 
 ![figure](./docs/figure_templates.png)
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -12,6 +12,9 @@
 <p align="center">
     <a href="https://github.com/jihe520/MathModelAgent/releases/latest"><b>⬇️ Download the latest desktop app (recommended)</b></a>
 </p>
+<p align="center">
+    🎨 Sister project: <a href="https://github.com/jihe520/sci-box"><b>sci-box</b></a> — scientific figure & diagram SKILLs
+</p>
 
 ---
 
@@ -64,6 +67,21 @@ Automatically generate an award-level modeling paper
 - 🤖 Support for all models: [litellm](https://docs.litellm.ai/docs/providers)
 - 💰 Low cost: workflow agentless, no dependency on agent framework
 - 🧩 Custom templates: prompt inject for setting requirements for each subtask separately
+
+## 🎨 Sister Project: sci-box (Figures & Diagrams)
+
+The scientific plotting and diagram templates now live in their own repository, **[jihe520/sci-box](https://github.com/jihe520/sci-box)**, and can be installed and used on their own:
+
+| SKILL | Contents |
+|-------|----------|
+| `scibox-figure` | Ready-to-run replication templates for SHAP, ROC, Taylor, raincloud, chord and circular heatmap plots (Python + Matplotlib, exports PNG / PDF / SVG) |
+| `scibox-diagram` | Editable draw.io templates: five-tier technical roadmap, three-column research framework, three-column process flow, horizontal task pipeline |
+
+```
+npx skills add jihe520/sci-box
+```
+
+![figure](./docs/figure_templates.png)
 
 ## 🚀 Future Plans
 


### PR DESCRIPTION
科研绘图和流程图模板已独立到 [jihe520/sci-box](https://github.com/jihe520/sci-box)，README 里补上入口。

## 改动

- **README.md / README_EN.md 顶部**：在「下载桌面版」下方加一行居中的姊妹项目链接，进仓库第一屏可见。
- **新增独立小节** `🎨 姊妹项目：sci-box（科研图表 & 流程图）` / `🎨 Sister Project: sci-box`：有独立锚点，会出现在 GitHub 目录侧栏；用表格区分 `scibox-figure`（SHAP / ROC / Taylor / 云雨图 / 和弦图等 Matplotlib 模板）和 `scibox-diagram`（draw.io 技术路线图与流程图模板），并给出 `npx skills add jihe520/sci-box`。
- 原中文 README 里那句「skills 中包含一个科研绘图模板skill」被上述小节替代，预览图 `docs/figure_templates.png` 保留。

纯文档改动，无代码变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)