### PR TITLE
fix(skills): Windows 下 python3 硬编码导致 6verity/doctor 失效

### DIFF
--- a/skills/6verity/scripts/writing_check.sh
+++ b/skills/6verity/scripts/writing_check.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -u
 
+# Windows (python.org installer / Git Bash) usually only provides `python`,
+# while Linux/macOS provide `python3`. Pick whichever exists.
+PYTHON_BIN="$(command -v python3 || command -v python || true)"
+if [ -z "$PYTHON_BIN" ]; then
+  echo "ERROR: python3 (or python) not found in PATH" >&2
+  exit 2
+fi
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -27,6 +35,11 @@ the actual files it wants checked.
 EOF
 }
 
+die_missing_value() {
+  echo "ERROR: $1 requires a value" >&2
+  exit 2
+}
+
 PAPER_DIR="${PAPER_DIR:-}"
 ROOT_DIR="${ROOT_DIR:-}"
 MAIN_FILE="${MAIN_FILE:-}"
@@ -43,43 +56,53 @@ POSITIONAL=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --paper-dir)
-      PAPER_DIR="${2:-}"
+      [ "$#" -ge 2 ] || die_missing_value "$1"
+      PAPER_DIR="$2"
       shift 2
       ;;
     --root-dir)
-      ROOT_DIR="${2:-}"
+      [ "$#" -ge 2 ] || die_missing_value "$1"
+      ROOT_DIR="$2"
       shift 2
       ;;
     --main)
-      MAIN_FILE="${2:-}"
+      [ "$#" -ge 2 ] || die_missing_value "$1"
+      MAIN_FILE="$2"
       shift 2
       ;;
     --sections-dir)
-      SECTIONS_DIR="${2:-}"
+      [ "$#" -ge 2 ] || die_missing_value "$1"
+      SECTIONS_DIR="$2"
       shift 2
       ;;
     --references)
-      REFERENCES_FILE="${2:-}"
+      [ "$#" -ge 2 ] || die_missing_value "$1"
+      REFERENCES_FILE="$2"
       shift 2
       ;;
     --figures-dir)
-      FIGURES_DIR="${2:-}"
+      [ "$#" -ge 2 ] || die_missing_value "$1"
+      FIGURES_DIR="$2"
       shift 2
       ;;
     --results-file)
-      RESULTS_FILE="${2:-}"
+      [ "$#" -ge 2 ] || die_missing_value "$1"
+      RESULTS_FILE="$2"
       shift 2
       ;;
     --problem-analysis)
-      PROBLEM_ANALYSIS_FILE="${2:-}"
+      [ "$#" -ge 2 ] || die_missing_value "$1"
+      PROBLEM_ANALYSIS_FILE="$2"
       shift 2
       ;;
     --all-results)
-      ALL_RESULTS_FILE="${2:-}"
+      [ "$#" -ge 2 ] || die_missing_value "$1"
+      ALL_RESULTS_FILE="$2"
       shift 2
       ;;
     --internal-term)
-      EXTRA_INTERNAL_TERMS+=("${2:-}")
+      [ "$#" -ge 2 ] || die_missing_value "$1"
+      EXTRA_INTERNAL_TERMS+=("$2")
       shift 2
       ;;
     --no-internal-check)
@@ -185,7 +208,7 @@ else
 fi
 export EXTRA_INTERNAL_TERMS_STR
 
-python3 - <<'PY'
+"$PYTHON_BIN" - <<'PY'
 import json
 import os
 import re

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -16,7 +16,7 @@ allowed-tools: Bash(*), Read, Write
 | --- | --- | --- |
 | `typst` | 论文编译（5writing、6verity，Typst 引擎） | `command -v typst` |
 | `xelatex` | 论文编译（5writing、6verity，LaTeX 引擎，中文模板必需） | `command -v xelatex` |
-| `python3` | 数值计算与图表（3coding-visual） | `command -v python3` |
+| `python3` / `python` | 数值计算与图表（3coding-visual） | `command -v python3 \|\| command -v python` |
 | `drawio` / `draw.io` | DrawIO 流程图导出 PDF（4drawio） | `command -v drawio \|\| command -v draw.io` |
 | `pdftoppm` | PDF 转 PNG 视觉检查（6verity） | `command -v pdftoppm` |
 | `mutool` | PDF 转 PNG 备用（6verity） | `command -v mutool` |
@@ -55,7 +55,7 @@ if [ -f /etc/os-release ]; then
   . /etc/os-release
   echo "DISTRO=$ID"
 fi
-# Windows 包管理器检测（在 Git Bash / PowerShell 中）
+# Windows 包管理器检测（在 Git Bash 中；PowerShell 请使用 Get-Command winget 等）
 command -v winget >/dev/null 2>&1 && echo "PKG=winget"
 command -v scoop  >/dev/null 2>&1 && echo "PKG=scoop"
 command -v choco  >/dev/null 2>&1 && echo "PKG=choco"
@@ -64,13 +64,21 @@ command -v choco  >/dev/null 2>&1 && echo "PKG=choco"
 ### Step 2：检查所有工具
 
 ```bash
+# Windows（python.org 安装包 / Git Bash）通常只有 `python`，Linux/macOS 为 `python3`。
+# 注意：check_cmd 必须显式 return，否则函数以 echo 的退出码（恒为 0）结尾，
+# `check_cmd a || check_cmd b` 的回退分支永远不会执行。
 check_cmd() {
   if command -v "$1" >/dev/null 2>&1; then
     echo "OK  $1 ($(command -v "$1"))"
+    return 0
   else
     echo "MISS $1"
+    return 1
   fi
 }
+
+# 统一探测可用的 Python 解释器，供下方包检测使用
+PYTHON_BIN="$(command -v python3 || command -v python || true)"
 
 check_cmd typst
 check_cmd xelatex
@@ -81,7 +89,10 @@ check_cmd pdftoppm
 check_cmd mutool
 check_cmd magick
 
-python3 - <<'PYEOF'
+if [ -z "$PYTHON_BIN" ]; then
+  echo "MISS python3/python，跳过 Python 包检测"
+else
+"$PYTHON_BIN" - <<'PYEOF'
 import importlib
 pkgs = ["numpy", "scipy", "pandas", "matplotlib", "sklearn", "openpyxl"]
 for p in pkgs:
@@ -96,6 +107,7 @@ for p in pkgs:
     except ImportError:
         print(f"MISS {p}")
 PYEOF
+fi
 ```
 
 ### Step 3：输出检查报告
@@ -112,7 +124,7 @@ PYEOF
 ...
 ```
 
-**必须项：** typst 或 xelatex（至少一个论文编译器）、python3、numpy、pandas、matplotlib  
+**必须项：** typst 或 xelatex（至少一个论文编译器）、python3/python、numpy、pandas、matplotlib  
 **可选项：** drawio、pdftoppm/mutool/magick 三选一、scipy、scikit-learn、openpyxl
 
 ### Step 4：提供安装命令（按平台）


### PR DESCRIPTION
> 关联 issue：#114

## Summary

修复 Windows（原生 Python + Git Bash，无 `python3` 命令）环境下两个质量关卡失效的问题：

- **`skills/6verity/scripts/writing_check.sh`**
  - 脚本开头探测 `python3` / `python` 任一可用解释器（`PYTHON_BIN`），heredoc 改用探测结果；两者都缺失时输出明确错误并以退出码 2 退出，而不是 `python3: command not found`。
  - 修复选项缺值时的死循环：`--paper-dir` 等带值选项位于末尾（缺值）时，原实现 `shift 2` 无法消费参数导致 `while` 永真刷屏；现在统一报 `ERROR: <option> requires a value` 并以退出码 2 退出（新增 `die_missing_value` 辅助函数）。
- **`skills/doctor/SKILL.md`**
  - `check_cmd` 函数补显式 `return 0` / `return 1`——原实现以 `echo` 结尾恒返回 0，导致 `check_cmd python3 || check_cmd python` 的回退分支永远不执行（Windows 上 `python` 明明存在却报 MISS，误导后续安装向导）。
  - Python 包检测段改用探测到的 `PYTHON_BIN` 执行 heredoc，并在无解释器时显式跳过提示。
  - 修正 "command -v 在 PowerShell 中可用" 的错误说明（POSIX 内建，PowerShell 应使用 `Get-Command`）。
  - 核心工具表格与"必须项"表述同步为 `python3 / python`。

## 行为对比

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| Windows 上运行 writing_check.sh | `python3: command not found`，验收门禁失效 | 探测到 `python`，完整执行全部检查 |
| Windows 上运行 doctor Step 2 | `MISS python3`（即使 python 已装），包检测报错 | `MISS python3` 后回退 `OK python`，包检测完整执行 |
| `writing_check.sh --paper-dir`（缺值） | 死循环刷屏 | `ERROR: --paper-dir requires a value`，退出码 2 |
| Linux/macOS | 正常 | 行为不变（优先 `python3`） |

## 验证

在 Windows 10 + Git Bash（`command -v python3` 为空、`python` = 3.12.8）实测：

1. `bash -n` 语法检查通过；
2. `writing_check.sh --paper-dir <含 PLACEHOLDER 的测试目录>`：探测到 `python` 并完整执行，正确输出 `FAIL: placeholder text remains ...`（门禁逻辑生效）；
3. `writing_check.sh --paper-dir`（缺值）：立即报错退出（exit=2），不再死循环；
4. doctor SKILL.md 的 Step 2 代码块原样提取执行：`MISS python3` → `OK python (...)` 回退生效，6 个 Python 包检测全部经 `python` 执行；
5. doctor 原版 `check_cmd` 的回退失效问题已单独复现确认（函数返回值恒为 0）。

## 备注

- 桌面版内置 Claude Code + 全套 skills，Claude Code 在 Windows 上经 Git Bash 执行这些脚本，因此该修复直接惠及所有 Windows 桌面版用户的验收与诊断流程。
- 改动保持 bash 3.2 兼容（未使用 bash 4+ 特性），macOS 老版本 bash 不受影响。