### PR TITLE
fix: win_start.bat 兼容 .venv 并增加启动前置检查

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,8 @@ $env:ENV="DEV"
 $env:REDIS_URL="redis://localhost:6379/0"
 # 2. 设置 PowerShell 执行策略策略为 RemoteSigned
 Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
-# 3. 创建虚拟环境
+# 3. 创建虚拟环境（若已执行过 uv sync 则可跳过本步，其虚拟环境为 .venv；
+#    win_start.bat 会自动探测 venv / .venv 两者之一）
 python -m venv venv
 ```
 
@@ -329,11 +330,11 @@ source .venv/bin/activate
 uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws-ping-interval 60 --ws-ping-timeout 120 --reload
 ```
 
-```bash
+```powershell
 # ============ Windows PowerShell 安装命令 ============
 # 1. 切换到 backend 目录
 cd .\backend\
-# 2. 激活虚拟环境
+# 2. 激活虚拟环境（uv sync 用户路径为 .\.venv\Scripts\Activate.ps1）
 .\venv\Scripts\Activate.ps1
 # 3. 启动后端服务
 uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws-ping-interval 60 --ws-ping-timeout 120 --reload

--- a/win_start.bat
+++ b/win_start.bat
@@ -1,19 +1,57 @@
 @echo off
 chcp 65001 >nul
+
 echo ==============================================
 echo  一键启动 Redis + 后端FastAPI + 前端Vue/React
 echo ==============================================
 echo.
 
-:: ====================== 启动 Redis ======================
+:: ====================== 前置检查 ======================
+:: 不使用括号块：cmd 解析含中文的括号块时会把后续 echo 行拆断执行
+where redis-server >nul 2>&1
+if not errorlevel 1 goto :check_pnpm
+echo [错误] 未找到 redis-server，请先安装 Redis 并加入 PATH:
+echo        Windows 下载地址: https://github.com/tporadowski/redis/releases
+goto :fail
+
+:check_pnpm
+where pnpm >nul 2>&1
+if not errorlevel 1 goto :check_venv
+echo [错误] 未找到 pnpm，请先执行: npm install -g pnpm
+goto :fail
+
+:: ====================== 探测后端虚拟环境 ======================
+:: README 的 uv sync 流程生成 .venv，PowerShell 教程生成 venv，两者均支持
+:check_venv
+set "VENV_DIR="
+if exist ".\backend\venv\Scripts\Activate.bat" set "VENV_DIR=venv"
+if not defined VENV_DIR if exist ".\backend\.venv\Scripts\Activate.bat" set "VENV_DIR=.venv"
+if defined VENV_DIR goto :start_all
+
+echo [错误] 未找到后端虚拟环境 backend\venv 或 backend\.venv
+echo        请先按 README 安装后端依赖: cd backend 然后 uv sync
+goto :fail
+
+:: ====================== 启动服务 ======================
+:start_all
+echo 使用后端虚拟环境: backend\%VENV_DIR%
+echo.
+
 start "Redis 服务" cmd /k "redis-server"
 
-:: ====================== 启动 后端 ======================
-start "后端服务" cmd /k "cd /d .\backend && .\venv\Scripts\Activate.bat && uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws-ping-interval 60 --ws-ping-timeout 120 --reload"
+start "后端服务" cmd /k "cd /d .\backend && .\%VENV_DIR%\Scripts\Activate.bat && uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws-ping-interval 60 --ws-ping-timeout 120 --reload"
 
-:: ====================== 启动 前端 ======================
 start "前端服务" cmd /k "cd /d .\frontend && pnpm run dev"
 
-echo 三个服务已全部启动！
+echo 三个服务已启动，请等待各窗口内服务就绪。
 echo.
+goto :end
+
+:fail
+echo.
+echo 启动中止: 请根据上方提示修复后重试。
+pause
+exit /b 1
+
+:end
 pause


### PR DESCRIPTION
## Summary

`win_start.bat` 此前硬编码激活 `.\backend\venv\`，但 README「安装后端依赖」一节推荐的流程是 `pip install uv; uv sync`（生成的是 `backend\.venv\`）。**照官方文档操作后，双击一键启动脚本直接失败**（Activate.bat 路径不存在），README 第 315 行还明确承诺"windows用户直接双击运行 win_start.bat 即可启动项目"。

改动：

- **虚拟环境探测**：优先 `backend\venv`（保持现有用户路径不变），不存在则回退 `backend\.venv`（uv sync 产物）；两者都没有时给出明确的中文指引（提示执行 `cd backend` + `uv sync`）后退出，不再无声闪退。
- **启动前置检查**：运行前用 `where` 检查 `redis-server` 与 `pnpm` 是否在 PATH，缺失时输出对应安装指引（Redis 的 Windows 下载地址 / `npm install -g pnpm`）并中止。
- **README 一致性**（2 处小改）：
  - PowerShell 创建虚拟环境处注明"若已执行 uv sync 可跳过，win_start.bat 会自动探测 venv / .venv"；
  - step2 Windows 激活命令处注明 uv sync 用户的路径为 `.\.venv\Scripts\Activate.ps1`。

## 技术说明

- 逐段采用 `goto` 跳转而非括号块：实测发现 cmd 解析**含中文的括号块**时会把后续 `echo` 行拆断执行（`'Windows' is not recognized`），改为 goto 结构后稳定。此问题已在 Windows 10 实机复现并验证修复。
- venv 探测使用 `if exist` + `if not defined` 链式判断，无嵌套括号块。
- 保持 UTF-8 无 BOM + CRLF + `chcp 65001` 原有约定不变。

## 验证

在 Windows 10 实机（Git Bash 环境构造测试副本、注释 start 行避免弹窗）覆盖 4 个场景：

| 场景 | 结果 |
|------|------|
| 无 redis-server（本机未装） | 输出错误提示 + 下载地址行，干净退出（原版会继续启动三个窗口） |
| 仅存在 `backend\.venv`（uv sync 用户） | 正确探测 `backend\.venv`（**原版此场景直接失败**） |
| `venv` 与 `.venv` 并存 | 优先 `venv`，与现有行为一致 |
| 两者皆无 | 输出修复指引后退出（原版为裸的"系统找不到指定的路径"） |

中文输出、URL 显示、错误退出码（exit /b 1）均验证正常。