### PR TITLE
docs(readme_en): 修复照做即失败的 Windows 命令与 .env 文件引用

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -129,13 +129,12 @@ Three deployment options are available, choose the one that suits you best:
 1. Configure Environment Variables
 
 ```bash
-cp backend/.env.dev.example backend/.env.dev
-cp frontend/.env.example frontend/.env.development
+cp backend/.env.example backend/.env.dev
 ```
 
 Fill in the configuration in:
 - backend/.env.dev
-- frontend/.env.development
+- frontend/.env.development (already in the repo, edit it directly)
 
 2. Start Services
 
@@ -155,13 +154,13 @@ You can now access:
 
 1. Configure Environment Variables
 
-Copy `/backend/.env.dev.example` to `/backend/.env.dev` (remove the `.example` suffix)
+Copy `/backend/.env.example` to `/backend/.env.dev` (remove the `.example` suffix)
 
 **Configure Environment Variables**
 
 It is recommended to use models with strong capabilities and large parameter counts.
 
-Copy `/frontend/.env.example` to `/frontend/.env.development` (remove the `.example` suffix)
+Edit `/frontend/.env.development` directly (the file is already in the repo)
 
 2. Install Dependencies
 
@@ -182,11 +181,12 @@ uv sync # Install dependencies
 # Start backend
 # Activate Python virtual environment
 source .venv/bin/activate # MacOS or Linux
-venv\Scripts\activate.bat # Windows
+.venv\Scripts\activate.bat # Windows (uv sync creates .venv)
 # Run this command for MacOS or Linux
 ENV=DEV uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws-ping-interval 60 --ws-ping-timeout 120 --reload
-# Run this command for Windows
-set ENV=DEV ; uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws-ping-interval 60 --ws-ping-timeout 120
+# Run these commands for Windows (cmd does not treat ';' as a command separator)
+set ENV=DEV
+uvicorn app.main:app --host 0.0.0.0 --port 8000 --ws-ping-interval 60 --ws-ping-timeout 120 --reload
 ```
 
 Start frontend


### PR DESCRIPTION
## Summary

README_EN.md 中有 4 处"照文档操作第一步就失败"的错误：

1. **Windows 命令分隔符错误**（原第 189 行）：
   ```
   set ENV=DEV ; uvicorn app.main:app --host 0.0.0.0 --port 8000 ...
   ```
   cmd 不把 `;` 当命令分隔符——整串 `DEV ; uvicorn ...` 会被赋值给 `ENV`，uvicorn 根本不会执行。且该行丢失 `--reload` 参数（与 macOS/Linux 行不一致）。改为分两行命令并补齐参数。

2. **虚拟环境路径与安装流程矛盾**（原第 185 行）：`venv\Scripts\activate.bat`，而同块上一行 macOS/Linux 用的是 `source .venv/bin/activate`——上方步骤 `uv sync` 生成的是 `.venv`，Windows 路径应为 `.venv\Scripts\activate.bat`。

3. **不存在的 `backend/.env.dev.example`**（原第 132、158 行）：仓库中实际文件为 `backend/.env.example`，`cp backend/.env.dev.example ...` 直接报 No such file。

4. **不存在的 `frontend/.env.example`**（原第 133、164 行）：frontend 下的 `frontend/.env.development` 已在仓库中且被跟踪，无需（也无处）复制；改为"直接编辑该文件"。

## 验证

- 逐条对照仓库实际文件：`backend/.env.example` 存在、`frontend/.env.development` 存在、`frontend/.env.example` 不存在、`backend/.env.dev.example` 不存在；
- 修复后的命令在 Windows cmd 语义下可逐行执行（`set ENV=DEV` 单独一行）。

## 备注

中文版 README 对应步骤（`.\venv\Scripts\Activate.ps1` + uv sync 并存）的矛盾由另一个 PR（win_start.bat 自动探测 venv/.venv + README 注释）处理，本 PR 只修 README_EN 明确的错误，改动保持最小。